### PR TITLE
FEAT: Cell 선택 해제 기능 추가, 간단한 코드 리펙토링

### DIFF
--- a/shxxt-dev/src/common/store/propsReducer.ts
+++ b/shxxt-dev/src/common/store/propsReducer.ts
@@ -84,9 +84,16 @@ const PropsListSlice = createSlice({
       state[action.payload.shxxtName] = nextState;
     },
     changeSelectedCell(state, action: PayloadAction<SelectedCellInfo>) {
-      state[action.payload.shxxtName].selectedRow = action.payload.selectedRow;
-      state[action.payload.shxxtName].selectedColumn = action.payload.selectedColumn;
-      state[action.payload.shxxtName].propsList[action.payload.selectedRow][action.payload.selectedColumn].isSelected = true;
+      const { shxxtName, selectedRow, selectedColumn } = action.payload;
+      
+      // 굳이 이게 없어도 셀의 클릭 상태 변경은 가능.
+      // 현재 선택한 셀의 정보를 시트 전역적으로 갖고있는게 좋겠다고 생각해서 넣었었어
+      // 디자인 변경할 때 현재 어떤 셀/영역이 선택되어 있는지 정보가 필요하니까?
+      //state[shxxtName].selectedRow = selectedRow;
+      //state[shxxtName].selectedColumn = selectedColumn; 
+      
+      const prevState = state[shxxtName].propsList[selectedRow][selectedColumn].isSelected;
+      state[shxxtName].propsList[selectedRow][selectedColumn].isSelected = !prevState;
     },
   },
 });

--- a/shxxt-dev/src/index.tsx
+++ b/shxxt-dev/src/index.tsx
@@ -45,6 +45,7 @@ root.render(
         colNum={4}
         rowNum={4}
       />
+      {/*
       <div style={{width:300, height:200, backgroundColor:"yellow"}}>hiii</div>
       <Shxxt
         shxxtName={"twoSheet"}
@@ -53,6 +54,7 @@ root.render(
         colNum={4}
         rowNum={4}
       />
+      */}
     </div>
   </Provider>
 );


### PR DESCRIPTION
action.payload.xxx 를 계속 쓰는게 보기 안좋아서
내부 변수에 payload로 받아온 값을 저장해놓고 쓰도록 코드를 수정,
셀 클릭해서 선택을 해제하는 기능 추가